### PR TITLE
Reset chord hit state when generating new target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "clave",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/newNote.test.js"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -97,6 +97,7 @@ function showTarget(){
 }
 
 function newNote(){
+  chordHits.clear();
   current = chooseTarget();
   showTarget();
 }

--- a/test/newNote.test.js
+++ b/test/newNote.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const source = fs.readFileSync('./src/app.js', 'utf8');
+const match = source.match(/function\s+newNote\(\)\{([\s\S]*?)\n\}/);
+assert(match, 'newNote function not found');
+const body = match[1];
+assert(/chordHits\.clear\(\)/.test(body), 'chordHits.clear() not called in newNote');
+const idxClear = body.indexOf('chordHits.clear');
+const idxCurrent = body.indexOf('current =');
+assert(idxClear !== -1 && idxCurrent !== -1 && idxClear < idxCurrent, 'chordHits.clear() should come before setting current');
+console.log('newNote properly clears chordHits before choosing a new target');


### PR DESCRIPTION
## Summary
- Clear chordHits before selecting a new note or chord target
- Add test to ensure chordHits is reset prior to choosing new target

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc86a58330832a958df02cc3b50972