### PR TITLE
Add basic Node test setup and note utility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Recent versions of Chrome, Edge, and Firefox. iOS Safari works but may require a
 
 ---
 
+## 🧪 Tests
+
+Run all unit tests with:
+
+```bash
+npm test
+```
+
+---
+
 ## 🤝 Contributing
 
 PRs welcome! Please keep the code dependency‑free and easy to run. Suggestions and bug reports via Issues are appreciated.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "clave",
   "version": "1.0.0",
   "scripts": {
-    "test": "node test/newNote.test.js"
+    "test": "node --test"
   }
 }

--- a/test/newNote.test.js
+++ b/test/newNote.test.js
@@ -1,12 +1,18 @@
-const fs = require('fs');
-const assert = require('assert');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
 
-const source = fs.readFileSync('./src/app.js', 'utf8');
-const match = source.match(/function\s+newNote\(\)\{([\s\S]*?)\n\}/);
-assert(match, 'newNote function not found');
-const body = match[1];
-assert(/chordHits\.clear\(\)/.test(body), 'chordHits.clear() not called in newNote');
-const idxClear = body.indexOf('chordHits.clear');
-const idxCurrent = body.indexOf('current =');
-assert(idxClear !== -1 && idxCurrent !== -1 && idxClear < idxCurrent, 'chordHits.clear() should come before setting current');
-console.log('newNote properly clears chordHits before choosing a new target');
+test('newNote clears chordHits before choosing a new target', () => {
+  const source = fs.readFileSync('./src/app.js', 'utf8');
+  const match = source.match(/function\s+newNote\(\)\{([\s\S]*?)\n\}/);
+  assert.ok(match, 'newNote function not found');
+  const body = match[1];
+  assert.ok(/chordHits\.clear\(\)/.test(body), 'chordHits.clear() not called in newNote');
+  const idxClear = body.indexOf('chordHits.clear');
+  const idxCurrent = body.indexOf('current =');
+  assert.ok(
+    idxClear !== -1 && idxCurrent !== -1 && idxClear < idxCurrent,
+    'chordHits.clear() should come before setting current'
+  );
+});
+

--- a/test/notes.test.js
+++ b/test/notes.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('nameToMidi converts note names to MIDI numbers', async () => {
+  const { nameToMidi } = await import('../src/notes.js');
+  assert.strictEqual(nameToMidi('A4'), 69);
+  assert.strictEqual(nameToMidi('C4'), 60);
+  assert.throws(() => nameToMidi('H2'));
+});
+
+test('midiToFreq converts MIDI numbers to frequencies', async () => {
+  const { midiToFreq } = await import('../src/notes.js');
+  assert.strictEqual(midiToFreq(69), 440);
+  const c4 = midiToFreq(60);
+  assert.ok(Math.abs(c4 - 261.625565) < 1e-6);
+});
+
+test('normalizeName normalizes flats and casing', async () => {
+  const { normalizeName } = await import('../src/notes.js');
+  assert.strictEqual(normalizeName('Db4'), 'C#4');
+  assert.strictEqual(normalizeName('Bb3'), 'A#3');
+  assert.strictEqual(normalizeName('c#3'), 'C#3');
+});
+


### PR DESCRIPTION
## Summary
- use Node's built-in test runner and convert existing newNote test
- cover nameToMidi, midiToFreq and normalizeName helpers
- document `npm test` in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8a768e38832a88d3204622d176d0