### PR TITLE
feat: add dark theme toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,11 @@
   <title>Treino de Partitura</title>
   <link rel="stylesheet" href="../src/styles.css" />
 </head>
-<body>
+<body data-theme="light">
   <header class="topbar">
     <div class="logo" aria-hidden="true">🎵</div>
     <h1>Treino de Partitura</h1>
+    <button id="themeToggle" class="btn btn-small theme-toggle" aria-label="Alternar tema" aria-pressed="false">🌙</button>
   </header>
 
   <main class="container">

--- a/src/app.js
+++ b/src/app.js
@@ -26,6 +26,20 @@ const qwertyOctEl  = document.getElementById('qwertyOct');
 const resetChartBtn= document.getElementById('resetChartBtn');
 const chartCanvas  = document.getElementById('accuracyChart');
 const chartCtx     = chartCanvas.getContext('2d');
+const themeToggle  = document.getElementById('themeToggle');
+
+function applyTheme(theme){
+  document.body.dataset.theme = theme;
+  themeToggle.setAttribute('aria-pressed', theme === 'dark');
+  themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+}
+
+applyTheme(localStorage.getItem('theme') || 'light');
+themeToggle.addEventListener('click', ()=>{
+  const next = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+  localStorage.setItem('theme', next);
+});
 
 const staff  = new Staff(staffCanvas);
 const piano  = new Piano(keyboardRoot, { onPress: handlePress });

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,21 @@
   --lamp-sub: #9c27b0;
 }
 
+[data-theme="dark"]{
+  --bg: #121212;
+  --fg: #f5f7fb;
+  --muted: #bbb;
+  --brand: #6b6ff7;
+  --card: #1e1e1e;
+  --border: #333;
+  --ok: #66bb6a;
+  --err: #ef5350;
+  --focus: #8ab4f8;
+  --lamp: #555;
+  --lamp-on: #8ab4f8;
+  --lamp-sub: #ce93d8;
+}
+
 *{ box-sizing: border-box; }
 body{
   margin:0;
@@ -21,7 +36,7 @@ body{
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
 }
 
-.topbar{
+.topbar{ 
   display:flex;
   align-items:center;
   gap:12px;
@@ -31,6 +46,7 @@ body{
 }
 .topbar .logo{ font-size:24px }
 .topbar h1{ margin:0; font-size:20px; font-weight:700; letter-spacing:0.2px; }
+.topbar .theme-toggle{ margin-left:auto; }
 
 .container{
   max-width: 1400px;


### PR DESCRIPTION
## Summary
- add dark theme variables and toggle button
- persist chosen theme in localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc8b8dbd14832a8d5bbc31aea4fbe1