### PR TITLE
Add waveform and global volume control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,15 @@
 
           <button id="newBtn" class="btn" aria-label="Sortear nova nota">Nova nota</button>
           <button id="muteBtn" class="btn" aria-pressed="false" aria-label="Alternar som">🔈 Som: on</button>
+          <label for="waveSelect">Onda:</label>
+          <select id="waveSelect" aria-label="Forma de onda">
+            <option value="sine" selected>Seno</option>
+            <option value="square">Quadrada</option>
+            <option value="triangle">Triangular</option>
+            <option value="sawtooth">Serra</option>
+          </select>
+          <label for="volumeSlider">Volume:</label>
+          <input id="volumeSlider" type="range" min="0" max="1" step="0.01" value="1" aria-label="Volume global" />
         </div>
       </div>
 

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,8 @@ const scoreEl      = document.getElementById('score');
 const feedbackEl   = document.getElementById('feedback');
 const newBtn       = document.getElementById('newBtn');
 const muteBtn      = document.getElementById('muteBtn');
+const waveSelect   = document.getElementById('waveSelect');
+const volumeSlider = document.getElementById('volumeSlider');
 const levelSelect  = document.getElementById('levelSelect');
 const octaveMode   = document.getElementById('octaveMode');
 const keyboardRoot = document.getElementById('keyboard');
@@ -44,6 +46,8 @@ themeToggle.addEventListener('click', ()=>{
 const staff  = new Staff(staffCanvas);
 const piano  = new Piano(keyboardRoot, { onPress: handlePress });
 const synth  = new Synth();
+synth.setWave(waveSelect.value);
+synth.setVolume(parseFloat(volumeSlider.value || '1'));
 
 let score = 0;
 let current = null; // alvo: string (nota) ou array de 2 notas (DUO)
@@ -256,6 +260,8 @@ initEvents({
     windowInput,
     qwertyOctEl,
     resetChartBtn,
+    waveSelect,
+    volumeSlider,
     document
   },
   piano,

--- a/src/events.js
+++ b/src/events.js
@@ -12,6 +12,8 @@ export function initEvents(ctx) {
       windowInput,
       qwertyOctEl,
       resetChartBtn,
+      waveSelect,
+      volumeSlider,
       document
     },
     piano,
@@ -46,6 +48,14 @@ export function initEvents(ctx) {
     synth.setMuted(!now);
     muteBtn.textContent = now ? '🔈 Som: on' : '🔇 Som: off';
     muteBtn.setAttribute('aria-pressed', String(!now));
+  });
+
+  waveSelect.addEventListener('change', () => {
+    synth.setWave(waveSelect.value);
+  });
+
+  volumeSlider.addEventListener('input', () => {
+    synth.setVolume(parseFloat(volumeSlider.value || '1'));
   });
 
   levelSelect.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- expose `Synth.setWave(type)` and `setVolume()` with dedicated master gain node
- allow choosing waveform and global volume via UI controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8f34b2f8832a8cbd0f7e22e92d15