### PR TITLE
Add sample audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ game-partitura/
 
 ---
 
+## 🎧 Áudio amostrado
+
+1. Coloque arquivos `.wav` ou `.mp3` em `public/samples/` (crie a pasta se necessário).
+2. No código, carregue a amostra: `synth.loadSample('samples/seu-arquivo.wav', 440);` — o segundo parâmetro indica a frequência base da gravação.
+3. Na interface, escolha **Amostra** na lista de ondas para tocar usando o áudio carregado.
+
+Cada nota tocará a partir da amostra ajustando `playbackRate` conforme a frequência solicitada.
+
+---
+
 ## 🔧 Browser Support
 
 Recent versions of Chrome, Edge, and Firefox. iOS Safari works but may require an explicit tap to unlock audio. Ensure you serve over **http://** (localhost) rather than opening files directly.

--- a/public/index.html
+++ b/public/index.html
@@ -50,6 +50,7 @@
             <option value="square">Quadrada</option>
             <option value="triangle">Triangular</option>
             <option value="sawtooth">Serra</option>
+            <option value="sample">Amostra</option>
           </select>
           <label for="volumeSlider">Volume:</label>
           <input id="volumeSlider" type="range" min="0" max="1" step="0.01" value="1" aria-label="Volume global" />

--- a/src/app.js
+++ b/src/app.js
@@ -46,7 +46,13 @@ themeToggle.addEventListener('click', ()=>{
 const staff  = new Staff(staffCanvas);
 const piano  = new Piano(keyboardRoot, { onPress: handlePress });
 const synth  = new Synth();
-synth.setWave(waveSelect.value);
+// Exemplo de uso de amostra (coloque arquivos em public/samples)
+// synth.loadSample('samples/piano-A4.wav', 440);
+if (waveSelect.value === 'sample') {
+  synth.setVoice('sample');
+} else {
+  synth.setWave(waveSelect.value);
+}
 synth.setVolume(parseFloat(volumeSlider.value || '1'));
 
 let score = 0;

--- a/src/audio.js
+++ b/src/audio.js
@@ -5,6 +5,9 @@ export class Synth {
     this.ctx = new AC();
     this.muted = false;
     this.wave = 'sine';
+    this.voice = 'osc'; // 'osc' ou 'sample'
+    this.sample = null;
+    this.sampleBase = 440;
     this.master = this.ctx.createGain();
     this.master.gain.value = 1;
     this.master.connect(this.ctx.destination);
@@ -19,13 +22,38 @@ export class Synth {
     const allowed = ['sine','square','triangle','sawtooth'];
     if (allowed.includes(type)) this.wave = type;
   }
+  setVoice(type='osc'){
+    this.voice = type === 'sample' ? 'sample' : 'osc';
+  }
+  async loadSample(url, baseFreq=440){
+    const res = await fetch(url);
+    const buf = await res.arrayBuffer();
+    this.sample = await this.ctx.decodeAudioData(buf);
+    this.sampleBase = baseFreq;
+  }
   setVolume(v=1){
     const g = Math.max(0, Math.min(1, v));
     this.master.gain.setValueAtTime(g, this.ctx.currentTime);
   }
-  async beep(freq=440, dur=0.08, gain=0.25){
+  async beep(freq=440, dur=0.08, gain=0.25, forceOsc=false){
     await this.ensureRunning();
     if(this.muted) return;
+    if(!forceOsc && this.voice === 'sample' && this.sample){
+      const src = this.ctx.createBufferSource();
+      const g = this.ctx.createGain();
+      src.buffer = this.sample;
+      src.playbackRate.value = freq / this.sampleBase;
+      src.connect(g);
+      g.connect(this.master);
+      const now = this.ctx.currentTime;
+      g.gain.setValueAtTime(gain, now);
+      const maxDur = this.sample.duration / src.playbackRate.value;
+      const playDur = Math.min(maxDur, dur);
+      src.start(now);
+      src.stop(now + playDur);
+      src.onended = () => { try{src.disconnect();}catch{} try{g.disconnect();}catch{} };
+      return;
+    }
     const o = this.ctx.createOscillator();
     const g = this.ctx.createGain();
     o.type = this.wave;
@@ -45,6 +73,6 @@ export class Synth {
     if (this.muted) return;
     const freq = kind === 'main' ? 1000 : (kind === 'beat' ? 800 : 500);
     const gain = kind === 'sub' ? 0.18 : 0.26;
-    return this.beep(freq, 0.05, gain);
+    return this.beep(freq, 0.05, gain, true);
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -51,7 +51,13 @@ export function initEvents(ctx) {
   });
 
   waveSelect.addEventListener('change', () => {
-    synth.setWave(waveSelect.value);
+    const val = waveSelect.value;
+    if (val === 'sample') {
+      synth.setVoice('sample');
+    } else {
+      synth.setVoice('osc');
+      synth.setWave(val);
+    }
   });
 
   volumeSlider.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- allow Synth to load audio files and switch between oscillator and sample voices
- add "Amostra" option in UI and wiring to choose sample playback
- document how to add and use sampled audio files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc905f198c832abf6c28b7feb5ec5d