### PR TITLE
Render staff immediately on canvas initialization

### DIFF
--- a/src/staff.js
+++ b/src/staff.js
@@ -25,6 +25,7 @@ export class Staff {
     this.bg.width = this.cv.width; this.bg.height = this.cv.height;
     this.bgctx = this.bg.getContext('2d');
     this.drawStaff(this.bgctx);
+    this.ctx.drawImage(this.bg, 0, 0);
   }
 
   clear(){ this.ctx.clearRect(0, 0, this.cv.width, this.cv.height); }


### PR DESCRIPTION
## Summary
- Copy cached staff drawing to main canvas during Staff construction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bca032b620832ab17af694be04c8fb