### PR TITLE
Refactor layout separating controls panel from main content

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,48 +13,35 @@
     <button id="themeToggle" class="btn btn-small theme-toggle" aria-label="Alternar tema" aria-pressed="false">🌙</button>
   </header>
 
-  <main class="container">
-    <section class="staff-panel">
-      <canvas id="staffCanvas" width="760" height="520" aria-label="Pentagrama com nota"></canvas>
+  <div class="layout">
+    <aside class="controls-panel">
+      <div class="controls">
+        <label for="levelSelect">Nível:</label>
+        <select id="levelSelect" aria-label="Selecionar nível">
+          <option value="easy" selected>F3–E4 (básico)</option>
+          <option value="full">C1–B4 (com ♯)</option>
+          <option value="duo_easy">DUO F3–E4 (duas notas)</option>
+          <option value="duo_full">DUO C1–B4 (duas notas)</option>
+        </select>
 
-      <div class="hud">
-        <div class="left">
-          <div id="score" class="score" aria-live="polite">Pontos: 0</div>
-          <div id="feedback" class="feedback" aria-live="polite"></div>
-          <div class="beat">
-            <span>Beat:</span>
-            <div id="beatLamp" class="lamp" aria-hidden="true"></div>
-            <div id="subLamp" class="lamp sm" aria-hidden="true" title="Subdivisão"></div>
-          </div>
-        </div>
-        <div class="controls">
-          <label for="levelSelect">Nível:</label>
-          <select id="levelSelect" aria-label="Selecionar nível">
-            <option value="easy" selected>F3–E4 (básico)</option>
-            <option value="full">C1–B4 (com ♯)</option>
-            <option value="duo_easy">DUO F3–E4 (duas notas)</option>
-            <option value="duo_full">DUO C1–B4 (duas notas)</option>
-          </select>
+        <label for="octaveMode">Oitava (rótulos):</label>
+        <select id="octaveMode" aria-label="Padrão de oitava">
+          <option value="sci" selected>Científico (C4)</option>
+          <option value="daw">DAW/Yamaha (C3)</option>
+        </select>
 
-          <label for="octaveMode">Oitava (rótulos):</label>
-          <select id="octaveMode" aria-label="Padrão de oitava">
-            <option value="sci" selected>Científico (C4)</option>
-            <option value="daw">DAW/Yamaha (C3)</option>
-          </select>
-
-          <button id="newBtn" class="btn" aria-label="Sortear nova nota">Nova nota</button>
-          <button id="muteBtn" class="btn" aria-pressed="false" aria-label="Alternar som">🔈 Som: on</button>
-          <label for="waveSelect">Onda:</label>
-          <select id="waveSelect" aria-label="Forma de onda">
-            <option value="sine" selected>Seno</option>
-            <option value="square">Quadrada</option>
-            <option value="triangle">Triangular</option>
-            <option value="sawtooth">Serra</option>
-            <option value="sample">Amostra</option>
-          </select>
-          <label for="volumeSlider">Volume:</label>
-          <input id="volumeSlider" type="range" min="0" max="1" step="0.01" value="1" aria-label="Volume global" />
-        </div>
+        <button id="newBtn" class="btn" aria-label="Sortear nova nota">Nova nota</button>
+        <button id="muteBtn" class="btn" aria-pressed="false" aria-label="Alternar som">🔈 Som: on</button>
+        <label for="waveSelect">Onda:</label>
+        <select id="waveSelect" aria-label="Forma de onda">
+          <option value="sine" selected>Seno</option>
+          <option value="square">Quadrada</option>
+          <option value="triangle">Triangular</option>
+          <option value="sawtooth">Serra</option>
+          <option value="sample">Amostra</option>
+        </select>
+        <label for="volumeSlider">Volume:</label>
+        <input id="volumeSlider" type="range" min="0" max="1" step="0.01" value="1" aria-label="Volume global" />
       </div>
 
       <div class="rhythm-controls">
@@ -84,14 +71,32 @@
         <button id="resetChartBtn" class="btn btn-small">Resetar gráfico</button>
         <div id="keyMapForm" class="keymap-form" aria-label="Mapa de teclas"></div>
       </div>
+    </aside>
 
-      <canvas id="accuracyChart" width="760" height="160" aria-label="Gráfico de acerto (ms)"></canvas>
-    </section>
+    <section class="main-content">
+      <section class="staff-panel">
+        <canvas id="staffCanvas" width="760" height="520" aria-label="Pentagrama com nota"></canvas>
 
-    <section class="keyboard-panel">
-      <div id="keyboard" class="keyboard" aria-label="Teclado de piano"></div>
+        <div class="hud">
+          <div class="left">
+            <div id="score" class="score" aria-live="polite">Pontos: 0</div>
+            <div id="feedback" class="feedback" aria-live="polite"></div>
+            <div class="beat">
+              <span>Beat:</span>
+              <div id="beatLamp" class="lamp" aria-hidden="true"></div>
+              <div id="subLamp" class="lamp sm" aria-hidden="true" title="Subdivisão"></div>
+            </div>
+          </div>
+        </div>
+
+        <canvas id="accuracyChart" width="760" height="160" aria-label="Gráfico de acerto (ms)"></canvas>
+      </section>
+
+      <section class="keyboard-panel">
+        <div id="keyboard" class="keyboard" aria-label="Teclado de piano"></div>
+      </section>
     </section>
-  </main>
+  </div>
 
   <footer class="footer">
     <small>Protótipo educativo – sem dependências externas. ©</small>

--- a/src/styles.css
+++ b/src/styles.css
@@ -48,10 +48,32 @@ body{
 .topbar h1{ margin:0; font-size:20px; font-weight:700; letter-spacing:0.2px; }
 .topbar .theme-toggle{ margin-left:auto; }
 
-.container{
+.layout{
   max-width: 1400px;
   margin: 16px auto;
   padding: 0 16px 24px;
+  display:flex;
+  gap:16px;
+  align-items:flex-start;
+}
+
+.main-content{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.controls-panel{
+  width:280px;
+  background:var(--card);
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:16px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.04);
+  display:flex;
+  flex-direction:column;
+  gap:12px;
 }
 
 .staff-panel{
@@ -109,7 +131,6 @@ body{
   gap:8px;
   flex-wrap:wrap;
   color: var(--muted);
-  margin-top:8px;
 }
 .rhythm-controls .hint{ margin-left:auto; font-size:12px; }
 
@@ -125,7 +146,6 @@ body{
 }
 
 .keyboard-panel{
-  margin-top:16px;
   background:var(--card);
   border:1px solid var(--border);
   border-radius:16px;


### PR DESCRIPTION
## Summary
- Wrap staff and keyboard UI in a new `main-content` section
- Move interaction controls to a sibling `controls-panel` and arrange layout horizontally
- Add layout styles for new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bca46df3c0832aaf6b0e2e9a8b8215