### PR TITLE
Refine layout sizing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -29,6 +29,10 @@
 }
 
 *{ box-sizing: border-box; }
+html, body{
+  height:100%;
+  overflow:hidden;
+}
 body{
   margin:0;
   background: var(--bg);
@@ -50,22 +54,23 @@ body{
 
 .layout{
   max-width: 1400px;
-  margin: 16px auto;
-  padding: 0 16px 24px;
+  margin: 0 auto;
+  padding: 0;
   display:flex;
   gap:16px;
   align-items:flex-start;
+  height:calc(100vh - 64px);
+  overflow:hidden;
 }
 
 .main-content{
   flex:1;
   display:flex;
   flex-direction:column;
-  gap:16px;
 }
 
 .controls-panel{
-  width:280px;
+  width:260px;
   background:var(--card);
   border:1px solid var(--border);
   border-radius:16px;
@@ -74,13 +79,14 @@ body{
   display:flex;
   flex-direction:column;
   gap:12px;
+  overflow-y:auto;
 }
 
 .staff-panel{
   background:var(--card);
   border:1px solid var(--border);
   border-radius:16px;
-  padding:16px;
+  padding:0;
   display:flex;
   flex-direction:column;
   align-items:center;
@@ -149,7 +155,7 @@ body{
   background:var(--card);
   border:1px solid var(--border);
   border-radius:16px;
-  padding:16px;
+  padding:0;
   box-shadow: 0 4px 16px rgba(0,0,0,0.04);
 }
 


### PR DESCRIPTION
## Summary
- Ensure full-height layout with hidden overflow and set html/body dimensions
- Make controls panel scrollable and reduce width
- Remove extra padding from staff and keyboard panels so staff and keyboard fit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bca772ca5c832aaf59acf9dee15530