### PR TITLE
Make staff and keyboard responsive to window size

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -114,6 +114,25 @@ const state = {
 const accData = []; // array de offsets (ms), positivo = atraso, negativo = adiantado
 const MAX_POINTS = 80;
 
+function resizeLayout(){
+  // recalcula tamanhos de teclas e canvases
+  piano.layout();
+
+  const main = document.querySelector('.main-content');
+  const keyboardPanel = document.querySelector('.keyboard-panel');
+  const hud = document.querySelector('.hud');
+  const width = staffCanvas.parentElement.clientWidth;
+  const remaining = main.clientHeight - keyboardPanel.offsetHeight - hud.offsetHeight - chartCanvas.offsetHeight;
+  const height = Math.max(0, remaining);
+
+  chartCanvas.width = width;
+  staff.resize(width, height);
+  drawChart(chartCtx, chartCanvas, accData);
+  if(current) showTarget();
+}
+
+window.addEventListener('resize', resizeLayout);
+
 // Tecla física -> nota (dinâmico com baseOct). Shift = oitava acima.
 function keyToNote(e){
   const key = e.key.toLowerCase();
@@ -321,5 +340,5 @@ initEvents({
 });
 
 // init
-drawChart(chartCtx, chartCanvas, accData);
+resizeLayout();
 newNote();

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -7,7 +7,6 @@ export class Piano {
     this.onPress = onPress || (()=>{});
     this.keys = {};
     this.layout = this.layout.bind(this);
-    window.addEventListener('resize', this.layout);
     this.layout();
   }
 

--- a/src/staff.js
+++ b/src/staff.js
@@ -6,24 +6,50 @@ export class Staff {
   constructor(canvas){
     this.cv = canvas;
     this.ctx = canvas.getContext('2d');
-    this.padding = { left: 64, right: 24, top: 32, bottom: 32 };
-    this.spacing = 16; // distância entre as LINHAS do pentagrama
-    this.noteHeadRx = 9;
-    this.noteHeadRy = 6;
 
     this.topRefIdx    = diatonicIndex('F4');
     this.bottomRefIdx = diatonicIndex('E3');
-
-    this.stemHeight = 38;
-    this.stemOffset = 8;
-    this.noteX = this.padding.left + 56;
-
     this.stemUpThresholdIdx = diatonicIndex('B3');
 
-    // offscreen cache
     this.bg = document.createElement('canvas');
-    this.bg.width = this.cv.width; this.bg.height = this.cv.height;
     this.bgctx = this.bg.getContext('2d');
+
+    this.baseHeight = 520;
+    this.base = {
+      padding: { left:64, right:24, top:32, bottom:32 },
+      spacing:16,
+      noteHeadRx:9,
+      noteHeadRy:6,
+      stemHeight:38,
+      stemOffset:8,
+      noteXOffset:56
+    };
+
+    this.resize(canvas.width, canvas.height);
+  }
+
+  resize(w, h){
+    this.cv.width = w;
+    this.cv.height = h;
+    this.bg.width = w;
+    this.bg.height = h;
+    this.ctx = this.cv.getContext('2d');
+    this.bgctx = this.bg.getContext('2d');
+
+    const scale = h / this.baseHeight;
+    this.padding = {
+      left: this.base.padding.left * scale,
+      right: this.base.padding.right * scale,
+      top: this.base.padding.top * scale,
+      bottom: this.base.padding.bottom * scale,
+    };
+    this.spacing = this.base.spacing * scale;
+    this.noteHeadRx = this.base.noteHeadRx * scale;
+    this.noteHeadRy = this.base.noteHeadRy * scale;
+    this.stemHeight = this.base.stemHeight * scale;
+    this.stemOffset = this.base.stemOffset * scale;
+    this.noteX = this.padding.left + this.base.noteXOffset * scale;
+
     this.drawStaff(this.bgctx);
     this.ctx.drawImage(this.bg, 0, 0);
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -67,6 +67,7 @@ body{
   flex:1;
   display:flex;
   flex-direction:column;
+  height:100%;
 }
 
 .controls-panel{
@@ -92,6 +93,12 @@ body{
   align-items:center;
   gap:8px;
   box-shadow: 0 4px 16px rgba(0,0,0,0.04);
+  flex:1;
+}
+
+.staff-panel canvas{
+  width:100%;
+  height:auto;
 }
 
 .hud{
@@ -164,8 +171,7 @@ body{
   margin: 0 auto;
   width: 100%;
   max-width: 95vw;
-  height: 18vw;
-  max-height: 40vh;
+  height: 100%;
   user-select:none;
 }
 
@@ -217,7 +223,7 @@ body{
 #accuracyChart{
   width: 100%;
   max-width: 760px;
-  height: 160px;
+  height: auto;
   border:1px solid var(--border);
   border-radius: 10px;
   background: #fff;


### PR DESCRIPTION
## Summary
- Make staff and chart canvases scale to available space and keyboard height
- Add global resize handler to recalc canvas size and piano layout
- Scale staff drawing metrics so notes render correctly at any size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca90f1720832a8dd7e06983eb3f17