### PR TITLE
Add note label toggle and hide target note

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,8 @@
           <option value="daw">DAW/Yamaha (C3)</option>
         </select>
 
+        <label><input type="checkbox" id="noteNamesChk" checked> Mostrar nomes nas teclas</label>
+
         <button id="newBtn" class="btn" aria-label="Sortear nova nota">Nova nota</button>
         <button id="muteBtn" class="btn" aria-pressed="false" aria-label="Alternar som">🔈 Som: on</button>
         <label for="waveSelect">Onda:</label>

--- a/src/app.js
+++ b/src/app.js
@@ -30,6 +30,7 @@ const chartCanvas  = document.getElementById('accuracyChart');
 const chartCtx     = chartCanvas.getContext('2d');
 const themeToggle  = document.getElementById('themeToggle');
 const keyMapForm   = document.getElementById('keyMapForm');
+const noteNamesChk = document.getElementById('noteNamesChk');
 
 function applyTheme(theme){
   document.body.dataset.theme = theme;
@@ -45,7 +46,9 @@ themeToggle.addEventListener('click', ()=>{
 });
 
 const staff  = new Staff(staffCanvas);
-const piano  = new Piano(keyboardRoot, { onPress: handlePress });
+const showLabels = localStorage.getItem('showNoteLabels') !== 'false';
+if (noteNamesChk) noteNamesChk.checked = showLabels;
+const piano  = new Piano(keyboardRoot, { onPress: handlePress, showLabels });
 const synth  = new Synth();
 // Exemplo de uso de amostra (coloque arquivos em public/samples)
 // synth.loadSample('samples/piano-A4.wav', 440);
@@ -55,6 +58,14 @@ if (waveSelect.value === 'sample') {
   synth.setWave(waveSelect.value);
 }
 synth.setVolume(parseFloat(volumeSlider.value || '1'));
+
+if (noteNamesChk){
+  noteNamesChk.addEventListener('change', () => {
+    const show = noteNamesChk.checked;
+    piano.setShowLabels(show);
+    localStorage.setItem('showNoteLabels', String(show));
+  });
+}
 
 // Configurações de mapeamento de teclas (nota -> tecla)
 const NOTE_NAMES = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
@@ -163,11 +174,10 @@ function chooseTarget(){
 function showTarget(){
   if (Array.isArray(current)){
     staff.drawChord(current);
-    setFeedback('Alvo DUO: ' + current.map(toDisplayName).join(' + '));
   } else {
     staff.drawNote(current);
-    setFeedback('Alvo: ' + toDisplayName(current));
   }
+  setFeedback('');
 }
 
 function newNote(){

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -2,10 +2,11 @@
 import { normalizeName, toDisplayName } from './notes.js';
 
 export class Piano {
-  constructor(container, {onPress} = {}){
+  constructor(container, {onPress, showLabels = true} = {}){
     this.root = container;
     this.onPress = onPress || (()=>{});
     this.keys = {};
+    this.showLabels = showLabels;
     this.layout = this.layout.bind(this);
     this.layout();
   }
@@ -35,11 +36,14 @@ export class Piano {
         white.style.width = whiteW + 'px';
         white.style.height = whiteH + 'px';
         white.dataset.note = canonical;
-        white.textContent = toDisplayName(canonical); // label visível
+        const wLabel = toDisplayName(canonical);
+        white.dataset.label = wLabel;
+        white.textContent = this.showLabels ? wLabel : '';
 
         // A11y
         white.setAttribute('role', 'button');
         white.setAttribute('aria-pressed', 'false');
+        white.setAttribute('aria-label', wLabel);
         white.tabIndex = 0;
 
         // Pointer + Keyboard Events
@@ -65,10 +69,13 @@ export class Piano {
           black.style.width = blackW + 'px';
           black.style.height = blackH + 'px';
           black.dataset.note = bn;
-          black.textContent = toDisplayName(bn);
+          const bLabel = toDisplayName(bn);
+          black.dataset.label = bLabel;
+          black.textContent = this.showLabels ? bLabel : '';
 
           black.setAttribute('role', 'button');
           black.setAttribute('aria-pressed', 'false');
+          black.setAttribute('aria-label', bLabel);
           black.tabIndex = 0;
 
           black.addEventListener('pointerdown', ()=> this.press(bn));
@@ -102,5 +109,12 @@ export class Piano {
     if(!el) return;
     el.classList.remove('active');
     el.setAttribute('aria-pressed', 'false');
+  }
+
+  setShowLabels(show){
+    this.showLabels = show;
+    for (const el of Object.values(this.keys)){
+      el.textContent = show ? el.dataset.label : '';
+    }
   }
 }


### PR DESCRIPTION
## Summary
- remove target note name from feedback
- add checkbox to hide/show note names on piano and persist preference

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca3b8448c832a9f51953b97d7e147